### PR TITLE
Add Flow logs to GKE subnet

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -26,6 +26,12 @@
 #    range_name    = "${local.prefix}-subnet-gkeservices"
 #    ip_cidr_range = "240.0.128.32/27"
 #  }
+#
+#  log_config { # This is required due to an organization policy
+#    aggregation_interval = "INTERVAL_10_MIN"
+#    flow_sampling        = 0.3
+#    metadata             = "EXCLUDE_ALL_METADATA"
+#  }
 # }
 
 # resource "google_compute_router" "default" {


### PR DESCRIPTION
# 📑 Description
This PR does:

- Add subnet log config to the created subnets due to the organization policy created here: https://github.com/nosportugal/terraform-gcp-secops-p/pull/216

Ref https://github.com/nosportugal/terraform-gcp-org/issues/1387