### PR TITLE
Setting Terraform version to 1.5.7 to be compatible with GCP Cloudshell and updating the remaining providers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 ## terraform & providers
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.5.7"
   backend "local" {
     path = "terraform.tfstate"
   }
@@ -12,16 +12,16 @@ terraform {
     }
 
     kubectl = {
-      source = "alekc/kubectl"
-      version = "2.0.3"
+      source  = "alekc/kubectl"
+      version = "2.0.4"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.11"
+      version = "~> 2.14"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.23"
+      version = "~> 2.31"
     }
   }
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,5 +1,5 @@
 ## VPC registry:  https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network
-# VPC can be viewed here: https://console.cloud.google.com/networking/networks/list
+## VPC can be viewed here: https://console.cloud.google.com/networking/networks/list
 
 ## 1. Criação da VPC
 # resource "google_compute_network" "default" {


### PR DESCRIPTION
# 📑 Description

- Setting Terraform version to `1.5.7` to be compatible with GCP Cloudshell.
- Updating the remaining provider's versions.